### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -13,6 +13,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"


### PR DESCRIPTION
Potential fix for [https://github.com/draken0654-ui/whyopen/security/code-scanning/1](https://github.com/draken0654-ui/whyopen/security/code-scanning/1)

Add an explicit `permissions` block to the workflow, ideally at the top level so it applies to all jobs unless overridden. For this workflow, the minimal needed permission is:

- `contents: read`

This preserves current functionality (`actions/checkout` and echo commands) while constraining token scope.  
Edit `.github/workflows/blank.yml` by inserting the `permissions` section between the trigger section (`on:` ...) and `jobs:`.

No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
